### PR TITLE
ft-seacrch-product: add function to search a product

### DIFF
--- a/__test__/product.test.js
+++ b/__test__/product.test.js
@@ -2,10 +2,11 @@ import request from 'supertest';
 import app from '../src/app';
 import path from 'path';
 
-const { User, Products } = require('../src/database/models');
+const { User,Products } = require('../src/database/models');
 import { Categories } from '../src/database/models';
 import { generateToken } from '../src/utils/generateToken';
-
+// import {Products } from '../src/database/models';
+// import User from "../src/database/models"
 jest.setTimeout(50000);
 describe('Testing Products service', () => {
   let categories;
@@ -192,4 +193,82 @@ describe('Testing Products service', () => {
       .set('Authorization', `Bearer ${token}`)
     expect(response.statusCode).toBe(200);
   });
+});
+
+
+
+
+describe('Search products endpoint', () => {
+  let products;
+  beforeAll(async () => {
+    // Set up test data
+    const createUser = User.create({
+  firstname: "myfirstname",
+  lastname: "mysecondname",
+  email: "test@gmail.com",
+  password: "testpass2345",
+})
+     products = await Products.bulkCreate([
+      {
+        name: 'Product 1',
+        price: 10.0,
+        quantity: 5,
+        expiryDate: new Date('2022-01-01'),
+      },
+      {
+        name: 'Product 2',
+        price: 20.0,
+        quantity: 10,
+        expiryDate: new Date('2023-01-01'),
+      },
+      {
+        name: 'Product 3',
+        price: 30.0,
+        quantity: 15,
+        expiryDate: new Date('2023-01-01'),
+      },
+    ]);
+  });
+
+
+  it('should return 200 if user is not logged in', async () => {
+      
+    // Make a request to update the user status
+    const response = await request(app)
+      .get('/api/v1/products/search')
+      .set('Authorization', "" )
+
+    // Expect a 200 status code and error message
+    expect(response.status).toBe(401);
+  
+  });
+let UserToken
+  test('should return all products when no filters are specified', async () => {
+    const user = await User.findOne({where:{email:'test@gmail.com'}})
+    UserToken = generateToken(user)
+    const response = await request(app).get('/api/v1/products/search')
+   .set('Authorization', `Bearer ${UserToken}` )
+    expect(response.status).toBe(200);
+  });
+
+  test('should filter products by name', async () => {
+    const response = await request(app).get('/api/v1/products/search?name=Product 1')
+    .set('Authorization', `Bearer ${UserToken}` )
+    expect(response.status).toBe(200);
+  });
+
+  test('should filter products by price range', async () => {
+    const response = await request(app).get('/api/v1/products/search?minPrice=10&maxPrice=20')
+    .set('Authorization', `Bearer ${UserToken}` )
+    expect(response.status).toBe(200);
+
+  });
+
+  test('should filter products by price categoryId', async () => {
+    const response = await request(app).get('/api/v1/products/search?catego')
+    .set('Authorization', `Bearer ${UserToken}` )
+    expect(response.status).toBe(200);
+
+  });
+
 });

--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -38,8 +38,7 @@ const updateUserStatus = async (req, res) => {
       if (adminData.role !== 'admin') {
         return res.status(400).json({ error: 'Only admin users can update user status' });
       }
-const useree = req.params.id
-console.log(useree);
+
       const user = await User.User.findOne({ where: { id: req.params.id } });
 
       if (!user) {

--- a/src/controllers/product.controller.js
+++ b/src/controllers/product.controller.js
@@ -4,6 +4,12 @@ import verfyToken from '../utils/verifytoken.js';
 import 'dotenv/config';
 import { Op } from 'sequelize';
 import {Products } from '../database/models';
+import jwt from "jsonwebtoken"
+
+import User from "../database/models/index";
+import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
+import 'dotenv/config'
+import passport from "passport";
 
 const createProducts = async (req, res) => {
   try {
@@ -119,9 +125,32 @@ const retrieveItems = async (req, res) => {
 
 };
 
+const opts = {
+  jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+  secretOrKey: process.env.JWT_SECRET
+};
+
+passport.use(new JwtStrategy(opts, async (jwt_payload, done) => {
+  try {
+    const UserData = await User.User.findOne({where: {email: jwt_payload.data.email}})
+    if (!UserData) {
+      return done(null, false);
+    }
+    return done(null, UserData);
+  } catch (error) {
+    done(error, false);
+  }
+}));
 
 const searchProducts = async (req, res) => {
+  
   try {
+    passport.authenticate('jwt', { session: false }, async (err, UserData) => {
+      if (err) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+
     const { name, minPrice, maxPrice, categoryId, bestBefore } = req.query;
 
     const where = {};
@@ -131,9 +160,16 @@ const searchProducts = async (req, res) => {
     if (categoryId) where.categoryId = categoryId;
     if (bestBefore) where.expiryDate = { [Op.lt]: new Date(bestBefore) };
 
+    if (UserData.role == 'seller') {
+      where.sellerId = UserData.id;
+
+
+    }
+
     const products = await Products.findAll({ where });
     return res.status(200).json({ products });
-  } catch (err) {
+  })(req, res);
+}catch (err) {
     return res.status(500).json({ error: err.message });
   }
 };

--- a/src/controllers/product.controller.js
+++ b/src/controllers/product.controller.js
@@ -2,6 +2,8 @@
 import { createProduct, findProduct, findProducts } from '../services/product.service.js';
 import verfyToken from '../utils/verifytoken.js';
 import 'dotenv/config';
+import { Op } from 'sequelize';
+import {Products } from '../database/models';
 
 const createProducts = async (req, res) => {
   try {
@@ -117,4 +119,23 @@ const retrieveItems = async (req, res) => {
 
 };
 
-export { createProducts, retrieveItem, retrieveItems };
+
+const searchProducts = async (req, res) => {
+  try {
+    const { name, minPrice, maxPrice, categoryId, bestBefore } = req.query;
+
+    const where = {};
+    if (name) where.name = { [Op.iLike]: `%${name}%` };
+    if (minPrice) where.price = { [Op.gte]: minPrice };
+    if (maxPrice) where.price = { ...where.price, [Op.lte]: maxPrice };
+    if (categoryId) where.categoryId = categoryId;
+    if (bestBefore) where.expiryDate = { [Op.lt]: new Date(bestBefore) };
+
+    const products = await Products.findAll({ where });
+    return res.status(200).json({ products });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+export { createProducts, retrieveItem, retrieveItems, searchProducts};
+

--- a/src/database/seeders/20230316094505-create-categories.js.js
+++ b/src/database/seeders/20230316094505-create-categories.js.js
@@ -9,14 +9,32 @@ module.exports = {
       'Categories',
       [
         {
-          id: '1a2ef741-1488-4435-b2e2-4075a6a169ec',
+          id: 'a1a96a86-d898-45d2-896f-51898966b896',
           name: 'furniture',
           createdAt: new Date(),
           updatedAt: new Date(),
         },
         {
-          id: 'e0bebe02-acb2-440d-b445-267c3c586a9e',
+          id: 'a1a96a86-d898-45d2-896f-51898966b892',
           name: 'electronics',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'a1a96a86-d898-45d2-896f-51898966b893',
+          name: 'shoes',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'a1a96a86-d898-45d2-896f-51898966b894',
+          name: 'fruits',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'a1a96a86-d898-45d2-896f-51898966b895',
+          name: 'bags',
           createdAt: new Date(),
           updatedAt: new Date(),
         },

--- a/src/database/seeders/20230316094505-create-categories.js.js
+++ b/src/database/seeders/20230316094505-create-categories.js.js
@@ -9,13 +9,13 @@ module.exports = {
       'Categories',
       [
         {
-          id: '1a2ef741-1488-4435-b2e2-4075a6a169eb',
+          id: '1a2ef741-1488-4435-b2e2-4075a6a169ec',
           name: 'furniture',
           createdAt: new Date(),
           updatedAt: new Date(),
         },
         {
-          id: 'e0bebe02-acb2-440d-b445-267c3c586a9f',
+          id: 'e0bebe02-acb2-440d-b445-267c3c586a9e',
           name: 'electronics',
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/src/docs-data.js
+++ b/src/docs-data.js
@@ -598,3 +598,141 @@ export const userUpdatePassword = {
     },
   },
 };
+
+
+export const searchProducts = {
+  tags: ["search product"],
+  description: "Search for products by name, price range, category, or best before date",
+  operationId: "searchProducts",
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      description: 'Search products by name',
+      schema: {
+        type: 'string',
+      },
+    },
+    {
+      name: 'minPrice',
+      in: 'query',
+      description: 'Search products with a price greater than or equal to this value',
+      schema: {
+        type: 'number',
+      },
+    },
+    {
+      name: 'maxPrice',
+      in: 'query',
+      description: 'Search products with a price less than or equal to this value',
+      schema: {
+        type: 'number',
+      },
+    },
+    {
+      name: 'categoryId',
+      in: 'query',
+      description: 'Search products by category ID',
+      schema: {
+        type: 'string',
+      },
+    },
+    {
+      name: 'bestBefore',
+      in: 'query',
+      description: 'Search products with an expiry date before this date',
+      schema: {
+        type: 'string',
+        format: 'date',
+      },
+    },
+  ],
+  responses: {
+    200: {
+      description: "Success",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              products: {
+                type: "array",
+                items: {
+                  $ref: "#/components/schemas/Product",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    400: {
+      description: "Invalid request data",
+    },
+    404: {
+      description: "Product not found",
+    },
+    500: {
+      description: "Server error",
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+    schemas: {
+      Product: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          name: {
+            type: "string",
+          },
+          price: {
+            type: "number",
+          },
+          quantity: {
+            type: "integer",
+          },
+          isAvailable: {
+            type: "boolean",
+          },
+          categoryId: {
+            type: "integer",
+          },
+          sellerId: {
+            type: "integer",
+          },
+          bonus: {
+            type: "number",
+          },
+          images: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+          expiryDate: {
+            type: "string",
+            format: "date",
+          },
+          isExpired: {
+            type: "boolean",
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/routes/api/products.routes.js
+++ b/src/routes/api/products.routes.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createProducts, retrieveItem, retrieveItems } from '../../controllers/product.controller.js';
+import { createProducts, retrieveItem, retrieveItems, searchProducts } from '../../controllers/product.controller.js';
 import { productValidation } from '../../ validations/product.validation.js';
 import {
   isCategoryExist,
@@ -21,7 +21,7 @@ route.post(
   isProductExist,
   createProducts
 );
-
+route.get('/search',searchProducts)
 route.get('/:id', extractToken, retrieveItem);
 route.get('/', extractToken, retrieveItems);
 

--- a/src/routes/api/products.routes.js
+++ b/src/routes/api/products.routes.js
@@ -21,7 +21,7 @@ route.post(
   isProductExist,
   createProducts
 );
-route.get('/search',searchProducts)
+route.get('/search',extractToken,searchProducts)
 route.get('/:id', extractToken, retrieveItem);
 route.get('/', extractToken, retrieveItems);
 

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -15,6 +15,7 @@ import {
   assignUserRole,
   userUpdatePassword,
   verifyOTP,
+  searchProducts
 } from './docs-data';
 import 'dotenv/config';
 
@@ -99,6 +100,9 @@ export const swaggerDocument = {
       post: addCart,
       get: getCart,
       put: clearCart,
+    },
+    '/api/v1/products/search': {
+      get: searchProducts,
     },
   },
 };


### PR DESCRIPTION
### What does this PR do?

- [x] A user should be able to search a product



### Description of Task to be completed?

- A buyer needs to haver a way to search a product. by name, by price range, by category, best before, etc it can also be a combination of two or more with AND operation.

**additional functionality** 
- if a user searching for a product is a seller its only displays products for that seller only

### How should this be manually tested?

**Installation**
**1. Clone the repository by running** 
```
git clone https://github.com/atlp-rwanda/destructors-ec-bn.git
```
**2. Navigate to the project directory by running cd destructors-ec-bn.**
```
cd destructors-ec-bn
```
```
 cd  ft-search-product-184637155
```
**3. Install the necessary dependencies by running npm install.**
```
npm install
```
**4. Run the development server by running npm run dev. This will start the server using Nodemon, which will automatically reload the server when changes are made to the code.**
```
npm run dev
```
**5. Run the tests by running npm run test** 
```
npm run test
```
### Any background context you want to provide?
when running this on local server put into consideration the below information 👇 

- [x] add the the user `sign in  token` in headers with a key of `Authorization` and make sure that the value is started by `Bearer`

- for searching a product  end point  **PATCH: /api/v1/products/search**


### What are the relevant pivotal tracker/Trello stories?
- Tracker: 184637155
### Screenshots (if appropriate)

- none

### Questions:

- none