### PR TITLE
bg-fix-seacrch-product: add condition for min price not be greater th…

### DIFF
--- a/__test__/product.test.js
+++ b/__test__/product.test.js
@@ -454,6 +454,13 @@ let UserToken
 
   });
 
+  test('should give an error if the min price is greater than max price', async () => {
+    const response = await request(app).get('/api/v1/products/search?minPrice=50&maxPrice=20')
+    .set('Authorization', `Bearer ${UserToken}` )
+    expect(response.status).toBe(400);
+
+  });
+
   test('should filter products by price categoryId', async () => {
     const response = await request(app).get('/api/v1/products/search?catego')
     .set('Authorization', `Bearer ${UserToken}` )
@@ -461,4 +468,10 @@ let UserToken
 
   });
 
+  test('should given an error if the catedoryId is not valid', async () => {
+    const response = await request(app).get('/api/v1/products/search?categoryId=99000888-888888')
+    .set('Authorization', `Bearer ${UserToken}` )
+    expect(response.status).toBe(400);
+
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "supertest": "^6.3.3",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.2",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "uuid-validate": "^0.0.3"
       },
       "devDependencies": {
         "chai": "^4.3.7",
@@ -9977,6 +9978,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuid-validate": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.3.tgz",
+      "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w=="
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "license": "ISC",
@@ -16349,6 +16355,11 @@
     },
     "uuid": {
       "version": "9.0.0"
+    },
+    "uuid-validate": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.3.tgz",
+      "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "supertest": "^6.3.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.2",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "uuid-validate": "^0.0.3"
   },
   "devDependencies": {
     "chai": "^4.3.7",


### PR DESCRIPTION
### What does this PR do?

- [x] A user should be able to search a product



### Description of Task to be completed?

- A buyer needs to haver a way to search a product. by name, by price range, by category, best before, etc it can also be a combination of two or more with AND operation.
- bug fixed : added a condition saying that min price should not be greater than max price if so it returns an error and another condition to catch an error if the categoryId is not valid 

**additional functionality** 
- if a user searching for a product is a seller its only displays products for that seller only

### How should this be manually tested?

**Installation**
**1. Clone the repository by running** 
```
git clone https://github.com/atlp-rwanda/destructors-ec-bn.git
```
**2. Navigate to the project directory by running cd destructors-ec-bn.**
```
cd destructors-ec-bn
```
```
 cd  ft-search-product-184637155
```
**3. Install the necessary dependencies by running npm install.**
```
npm install
```
**4. Run the development server by running npm run dev. This will start the server using Nodemon, which will automatically reload the server when changes are made to the code.**
```
npm run dev
```
**5. Run the tests by running npm run test** 
```
npm run test
```
### Any background context you want to provide?
when running this on local server put into consideration the below information 👇 

- [x] add the the user `sign in  token` in headers with a key of `Authorization` and make sure that the value is started by `Bearer`

- for searching a product  end point  **PATCH: /api/v1/products/search**


### What are the relevant pivotal tracker/Trello stories?
- Tracker: 184637155
### Screenshots (if appropriate)

- none

### Questions:

- none