### PR TITLE
Bg fix Add get all orders endpoint

### DIFF
--- a/__test__/order.test.js
+++ b/__test__/order.test.js
@@ -2,7 +2,10 @@ import request from 'supertest';
 import app from '../src/app';
 import { User, Orders, Sales } from '../src/database/models';
 import { generateToken } from '../src/utils/generateToken';
+// import { expect } from 'chai';
+
 jest.setTimeout(30000);
+
 describe('Tracking the Order Status', () => {
   let orderId;
   let buyerId;
@@ -21,8 +24,7 @@ describe('Tracking the Order Status', () => {
       role: 'buyer',
     });
 
-    buyerId = await buyer.id;
-
+    buyerId = buyer.id;
     // Generate an access token for the test buyer
     buyerToken = generateToken(buyer);
 
@@ -34,7 +36,7 @@ describe('Tracking the Order Status', () => {
       status: 'payed',
     });
 
-    orderId = await order.id;
+    orderId = order.id;
 
     Sale = await Sales.create({
       orderId: orderId,
@@ -63,9 +65,12 @@ describe('Tracking the Order Status', () => {
 
   test('should return all orders for user', async () => {
     const res = await request(app)
-      .get(`/api/v1/orders/all`)
+      .get('/api/v1/orders')
       .set('Authorization', `Bearer ${buyerToken}`);
 
     expect(res.statusCode).toEqual(200);
+    expect(res.body.Orders.length).toEqual(1);
+    expect(res.body.Orders[0].id).toEqual(orderId);
+    expect(res.body.Orders[0].userId).toEqual(buyerId);
   });
 });

--- a/__test__/order.test.js
+++ b/__test__/order.test.js
@@ -41,7 +41,6 @@ describe('Tracking the Order Status', () => {
       sellerId: 'f6053eb8-247e-4964-aae4-147f90a4fd64',
       status: 'paid',
     });
-
   });
 
   test('should return the status of the order', async () => {
@@ -60,5 +59,13 @@ describe('Tracking the Order Status', () => {
 
     expect(res.statusCode).toEqual(404);
     expect(res.body.error).toEqual('Order not found');
+  });
+
+  test('should return all orders for user', async () => {
+    const res = await request(app)
+      .get(`/api/v1/orders/all`)
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(res.statusCode).toEqual(200);
   });
 });

--- a/src/controllers/orderStatus.controller.js
+++ b/src/controllers/orderStatus.controller.js
@@ -1,7 +1,6 @@
-import { Sales } from '../database/models';
-import { Orders } from '../database/models';
+import { Sales, Orders } from '../database/models';
 
-const trackOrderStatus = async (req, res) => {
+export const trackOrderStatus = async (req, res) => {
   try {
     const buyerId = req.user.id;
     const selectedOrder = await Orders.findOne({
@@ -31,4 +30,16 @@ const trackOrderStatus = async (req, res) => {
   }
 };
 
-export default trackOrderStatus;
+export const getOrders = async (req, res) => {
+  const buyerId = req.user.id;
+  const role = req.user.role;
+  const allOrders = await Orders.findAll({ where: { userId: buyerId } });
+  const orders = await Orders.findAll({});
+  if (role == 'admin') {
+    return res.status(200).json({ Orders: orders });
+  }
+  if (allOrders.length === 0) {
+    return res.status(404).json({ message: 'You have no order yet' });
+  }
+  return res.status(200).json({ Orders: allOrders });
+};

--- a/src/controllers/orders.controller.js
+++ b/src/controllers/orders.controller.js
@@ -1,6 +1,6 @@
 import { Sales, Orders } from '../database/models';
 
-export const trackOrderStatus = async (req, res) => {
+const trackOrderStatus = async (req, res) => {
   try {
     const buyerId = req.user.id;
     const selectedOrder = await Orders.findOne({
@@ -30,16 +30,34 @@ export const trackOrderStatus = async (req, res) => {
   }
 };
 
-export const getOrders = async (req, res) => {
+const getOrders = async (req, res) => {
   const buyerId = req.user.id;
   const role = req.user.role;
-  const allOrders = await Orders.findAll({ where: { userId: buyerId } });
-  const orders = await Orders.findAll({});
-  if (role == 'admin') {
-    return res.status(200).json({ Orders: orders });
-  }
+  const condition = role === 'admin' ? {} : { userId: buyerId };
+  const allOrders = await Orders.findAll({ where: condition });
   if (allOrders.length === 0) {
     return res.status(404).json({ message: 'You have no order yet' });
   }
   return res.status(200).json({ Orders: allOrders });
 };
+
+const getSales = async (req, res) => {
+  const sellerId = req.user.id;
+  const allOrders = await Orders.findAll({ attributes: ['products'] });
+  let allSales = [];
+    const mySales = allOrders.forEach((data) => {
+      data.products.map((element) => {
+        if (element.sellerId === sellerId) {
+        allSales.push(element);
+      }
+      })
+      
+    });
+      
+  if (allSales.length === 0) {
+    return res.status(404).json({ message: 'You have no order yet' });
+  }
+  return res.status(200).json({ Orders: allSales });
+};
+
+export { trackOrderStatus, getOrders, getSales };

--- a/src/documents/orderStatus.docs.js
+++ b/src/documents/orderStatus.docs.js
@@ -35,7 +35,21 @@ export const orderStatus = {
       },
     },
     401: {
-      $ref: '#/components/responses/Unauthorized',
+      description: 'Unauthorized',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                example: 'Unauthorized',
+              },
+            },
+            required: ['error'],
+          },
+        },
+      },
     },
     404: {
       description: 'The specified order does not exist',
@@ -55,7 +69,136 @@ export const orderStatus = {
       },
     },
     500: {
-      $ref: '#/components/responses/ServerError',
+      description: 'Server Error',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                example: 'Server Error',
+              },
+            },
+            required: ['error'],
+          },
+        },
+      },
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+    },
+    responses: {
+      Unauthorized: {
+        description: 'Unauthorized',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  example: 'Unauthorized',
+                },
+              },
+              required: ['error'],
+            },
+          },
+        },
+      },
+      ServerError: {
+        description: 'Server Error',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  example: 'Server Error',
+                },
+              },
+              required: ['error'],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const getOrders = {
+  summary: 'Get orders for a user',
+  tags: ['buyer order status'],
+  description:
+    'Returns orders placed by a user, or all orders if user is an admin',
+  responses: {
+    200: {
+      description: 'List of orders',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              Orders: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    id: {
+                      type: 'integer',
+                    },
+                    // Add other properties here
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    401: {
+      description: 'Unauthorized',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                example: 'Unauthorized',
+              },
+            },
+            required: ['error'],
+          },
+        },
+      },
+    },
+    404: {
+      description: 'No orders found',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     },
   },
   security: [

--- a/src/routes/api/orderStatus.routes.js
+++ b/src/routes/api/orderStatus.routes.js
@@ -1,8 +1,13 @@
 import { Router } from 'express';
 import extractToken from '../../middlewares/checkUserWithToken';
-import trackOrderStatus from '../../controllers/orderStatus.controller';
+import {
+  trackOrderStatus,
+  getOrders,
+} from '../../controllers/orderStatus.controller';
 
 const route = Router();
+
+route.get('/all', extractToken, getOrders);
 
 route.get('/:id/status', extractToken, trackOrderStatus);
 

--- a/src/routes/api/orders.routes.js
+++ b/src/routes/api/orders.routes.js
@@ -3,11 +3,13 @@ import extractToken from '../../middlewares/checkUserWithToken';
 import {
   trackOrderStatus,
   getOrders,
-} from '../../controllers/orderStatus.controller';
+  getSales
+} from '../../controllers/orders.controller';
 
 const route = Router();
 
-route.get('/all', extractToken, getOrders);
+route.get('/', extractToken, getOrders);
+route.get('/products', extractToken, getSales);
 
 route.get('/:id/status', extractToken, trackOrderStatus);
 

--- a/src/routes/api/salesDetails.routes.js
+++ b/src/routes/api/salesDetails.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import extractToken from '../../middlewares/checkUserWithToken';
+import {
+  getSales
+} from '../../controllers/orders.controller';
+
+const route = Router();
+
+route.get('/', extractToken, getSales);
+
+export default route;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,8 +9,9 @@ import payment from './api/payment.routes.js';
 import sale from './api/sale.routes.js';
 import stat from './api/stat.routes';
 import notification from './api/notification.routes.js';
-import orderStatus from './api/orderStatus.routes.js';
 import category from './api/category.routes.js';
+import orders from './api/orders.routes.js';
+import saleDetails from './api/salesDetails.routes.js'
 
 const routes = express.Router();
 routes.use('/', payment);
@@ -26,7 +27,9 @@ routes.use('/chats', chat);
 routes.use('/sales', sale);
 routes.use('/stats', stat);
 routes.use('/notifications', notification);
-routes.use('/orders', orderStatus);
+routes.use('/orders', orders);
+routes.use('/sales-details', saleDetails);
+
 
 
 

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -15,7 +15,7 @@ import {
   removeFromCart,
 } from './documents/cart.docs';
 import { payment } from './documents/payments.docs';
-import { orderStatus } from './documents/orderStatus.docs';
+import { orderStatus, getOrders } from './documents/orderStatus.docs';
 import {
   MarkNotificationRead,
   MarkAllNotificationRead,
@@ -189,6 +189,9 @@ export const swaggerDocument = {
     },
     '/api/v1/orders/{id}/status': {
       get: orderStatus,
+    },
+    '/api/v1/orders/all': {
+      get: getOrders,
     },
     '/api/v1/notifications/{id}': {
       patch: MarkNotificationRead,

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -190,7 +190,7 @@ export const swaggerDocument = {
     '/api/v1/orders/{id}/status': {
       get: orderStatus,
     },
-    '/api/v1/orders/all': {
+    '/api/v1/orders': {
       get: getOrders,
     },
     '/api/v1/notifications/{id}': {


### PR DESCRIPTION
### What does this PR do?

- [x] This is a bug fix of A Buyer should be able to track the status of the sales



### Description of Task to be completed?

- From the buyer's order, each product purchase needs to be tracked by the Buyer. The task is to empower the Buyer to be able to track the status of this product-purchase [sale, product-order] and check also the quantity  of the products


### How should this be manually tested?

**Installation**
**1. Clone the repository by running** 
```
git clone https://github.com/atlp-rwanda/destructors-ec-bn.git
```
**2. Navigate to the project directory by running cd destructors-ec-bn.**
```
cd destructors-ec-bn
```
```
 cd  ft-buyer-track-order-status-184637156
```
**3. Install the necessary dependencies by running npm install.**
```
npm install
```
**4. run migrations**
```
 npx sequelize-cli db:migrate
```
**5. run seeds**
```
npx sequelize-cli db:seed:all
```
**6. Run the development server by running npm run dev. This will start the server using Nodemon, which will automatically reload the server when changes are made to the code.**
```
npm run dev
```
**7. Run the tests by running npm run test** 
```
npm run test
```
### Any background context you want to provide?
when running this on a local server put into consideration the below information 👇 

- [x] add the  Buyer `sign in  token` in headers with a key of `Authorization` and make sure that the value is started by `Bearer`

- for Tracking sale status end point  **GET: /api/v1/orders/all**


### What are the relevant pivotal tracker stories?
- Tracker: 184637156
### Screenshots (if appropriate)

- none

### Questions:

- none
