### PR TITLE
fix: Build out endpoints for categories 

### DIFF
--- a/__test__/category.test.js
+++ b/__test__/category.test.js
@@ -1,0 +1,99 @@
+import request from 'supertest';
+import app from '../src/app';
+import { Categories } from '../src/database/models';
+import { User } from '../src/database/models';
+import { generateToken } from '../src/utils/generateToken';
+
+describe('Testing Categories endpoint', () => {
+  let buyerCategory;
+  let token;
+
+  beforeAll(async () => {
+    buyerCategory = await User.create({
+      firstname: 'myfirategory',
+      lastname: 'mysecondname',
+      email: 'testbuyercato1@gmail.com',
+      password: 'testpass2345',
+    });
+  });
+  test('should return 401 when user is not logged in', async () => {
+    const response = await request(app).post('/api/v1/categories').send({
+      name: 'shoes women',
+    });
+    expect(response.statusCode).toBe(401);
+  });
+  test('it should return 401 when user is not seller or admin', async () => {
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .post('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'shoes women',
+      });
+    expect(response.statusCode).toBe(401);
+  });
+  test('it should return 201 when user is seller or admin', async () => {
+    await buyerCategory.update({ role: 'seller' });
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .post('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'shoes women',
+      });
+    expect(response.statusCode).toBe(201);
+  });
+  test('it should return 400 when category name is empty', async () => {
+    await buyerCategory.update({ role: 'seller' });
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .post('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: '',
+      });
+    expect(response.statusCode).toBe(400);
+  });
+  test('it should return 404 when user category is already created', async () => {
+    await buyerCategory.update({ role: 'seller' });
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .post('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'shoes women',
+      });
+    expect(response.statusCode).toBe(404);
+  });
+  test('it should return 401 when for getting category to buyer', async () => {
+    await buyerCategory.update({ role: 'buyer' });
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .get('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'shoes women',
+      });
+    expect(response.statusCode).toBe(401);
+  });
+  test('should return 401 for retrieving category when user is not logged in', async () => {
+    const response = await request(app).get('/api/v1/categories');
+    expect(response.statusCode).toBe(401);
+  });
+  test('it should return 401 when for getting category to buyer', async () => {
+    await buyerCategory.update({ role: 'buyer' });
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .get('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`);
+    expect(response.statusCode).toBe(401);
+  });
+  test('it should return 200 when for getting category to seller or admin', async () => {
+    await buyerCategory.update({ role: 'seller' });
+    token = generateToken(buyerCategory);
+    const response = await request(app)
+      .get('/api/v1/categories')
+      .set('Authorization', `Bearer ${token}`);
+    expect(response.statusCode).toBe(200);
+  });
+});

--- a/src/ validations/category.validation.js
+++ b/src/ validations/category.validation.js
@@ -1,0 +1,14 @@
+import Joi from 'joi';
+const categorySchema = Joi.object({
+  name: Joi.string().required().min(3).max(255),
+});
+const categoryValdation = async (req, res, next) => {
+  const { error } = categorySchema.validate(req.body, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({
+      error: error.details[0].message.replace(/[^a-zA-Z0-9 ]/g, ''),
+    });
+  }
+  next();
+};
+export default categoryValdation;

--- a/src/controllers/category.controller.js
+++ b/src/controllers/category.controller.js
@@ -1,0 +1,34 @@
+import {
+  createCategory,
+  findAllCategories,
+} from '../services/category.service';
+
+const addCategories = async (req, res) => {
+  try {
+    const { name } = req.body;
+    const category = {
+      name: name.toLowerCase(),
+    };
+    const categories = await createCategory(category);
+    return res
+      .status(201)
+      .json({ message: 'Category added successfully', category: categories });
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: err.message, message: 'Something went wrong' });
+  }
+};
+const getAllCategories = async (req, res) => {
+  try {
+    const categories = await findAllCategories();
+    return res.status(200).json({ categories: categories });
+  } catch (err) {
+    return res.status(500).json({
+      error: err.message,
+      message: 'Something went wrong when retrieving categories',
+    });
+  }
+};
+
+export { addCategories, getAllCategories };

--- a/src/documents/category.docs.js
+++ b/src/documents/category.docs.js
@@ -1,0 +1,61 @@
+export const addCategory = {
+  tags: ['Categories'],
+  summary: 'Create category',
+  description: 'Creating a product category',
+  parameters: [],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              required: true,
+            },
+          },
+          example: {
+            name: 'clothing',
+          },
+        },
+      },
+    },
+  },
+  consumes: ['application/json'],
+  responses: {
+    201: {
+      description: 'category added successfull', // response desc
+    },
+    // response code
+    500: {
+      description: 'Server error', // response desc
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
+};
+
+export const getCategory = {
+  tags: ['Categories'],
+  summary: 'Get categories',
+  description: 'Listing categories',
+  responses: {
+    // response code
+    200: {
+      description: 'category succesfully retrieved', // response desc
+    },
+    // response code
+    500: {
+      description: 'Server error', // response desc
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
+};

--- a/src/middlewares/category.middleware.js
+++ b/src/middlewares/category.middleware.js
@@ -1,0 +1,12 @@
+import { Categories } from '../database/models';
+
+const isCategoryExistByName = async (req, res, next) => {
+  const { name } = req.body;
+  const isExist = await Categories.findOne({ where: { name } });
+  if (isExist) {
+    return res.status(404).json({ message: 'Category is already exist' });
+  }
+  next();
+};
+
+export { isCategoryExistByName };

--- a/src/routes/api/category.routes.js
+++ b/src/routes/api/category.routes.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import categoryValdation from '../../ validations/category.validation';
+import {
+  addCategories,
+  getAllCategories,
+} from '../../controllers/category.controller';
+import { isCategoryExistByName } from '../../middlewares/category.middleware';
+import checkRole from '../../middlewares/checkRole';
+import extractToken from '../../middlewares/checkUserWithToken.js';
+
+const route = express.Router();
+
+route.post(
+  '/',
+  extractToken,
+  checkRole(['seller', 'admin']),
+  categoryValdation,
+  isCategoryExistByName,
+  addCategories
+);
+route.get('/', extractToken, checkRole(['seller', 'admin']), getAllCategories);
+
+export default route;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,10 +6,11 @@ import cart from './api/cart.routes.js';
 import wishlist from './api/wishlist.routes';
 import chat from './api/chat.routes';
 import payment from './api/payment.routes.js';
-import sale from './api/sale.routes.js'
-import stat from './api/stat.routes'
+import sale from './api/sale.routes.js';
+import stat from './api/stat.routes';
 import notification from './api/notification.routes.js';
 import orderStatus from './api/orderStatus.routes.js';
+import category from './api/category.routes.js';
 
 const routes = express.Router();
 routes.use('/', payment);
@@ -19,11 +20,12 @@ routes.use('/users', updatePassword);
 routes.use('/carts', cart);
 routes.use('/product-wishes', wishlist);
 routes.use('/product-wishes', wishlist);
+routes.use('/categories', category);
 
 routes.use('/chats', chat);
-routes.use('/sales',sale)
-routes.use('/stats', stat)
-routes.use('/notifications', notification)
+routes.use('/sales', sale);
+routes.use('/stats', stat);
+routes.use('/notifications', notification);
 routes.use('/orders', orderStatus);
 
 export default routes;

--- a/src/services/category.service.js
+++ b/src/services/category.service.js
@@ -1,0 +1,11 @@
+import { Categories } from '../database/models';
+
+const createCategory = async (category) => {
+  return await Categories.create(category);
+};
+
+const findAllCategories = async () => {
+  return await Categories.findAll({});
+};
+
+export { createCategory, findAllCategories };

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -30,8 +30,9 @@ import {
   verifyEmail,
   getUserProfile,
   changeSaleStatu,
-  getSellerStats
+  getSellerStats,
 } from './docs-data';
+import { addCategory, getCategory } from './documents/category.docs';
 import 'dotenv/config';
 
 export const swaggerDocument = {
@@ -80,6 +81,10 @@ export const swaggerDocument = {
     },
     '/api/v1/users/reset-password/{token}': {
       patch: ResetPassword,
+    },
+    '/api/v1/categories': {
+      post: addCategory,
+      get: getCategory,
     },
     '/api/v1/products': {
       post: createProduct,


### PR DESCRIPTION
### What does this PR do?

- Build category endpoint 

### Description of Task to be completed?

- [x] A seller or admin should be able to add categories 
- [x] A seller or admin should be able to retrieve the list of categories 

### How should this be manually tested?

**Installation**
**1. Clone the repository by running** 
```
git clone https://github.com/atlp-rwanda/destructors-ec-bn.git
```
**2. Navigate to the project directory by running cd destructors-ec-bn.**
```
cd destructors-ec-bn
```
**3. Install the necessary dependencies by running npm install.**
```
npm install
```

**5. Navigate to  swagger and hit this endpoint .**  ``http://localhost:3000/api/v1/categories``
### Any background context you want to provide?
No
- Make sure that you have the required environment variables.

### What are the relevant pivotal tracker/Trello stories?

- Tracker: No

### Screenshots (if appropriate)

- none

### Questions:

- none